### PR TITLE
Optimizations

### DIFF
--- a/src/test/kotlin/com/oneeyedmen/anagrams/AnagramTests.kt
+++ b/src/test/kotlin/com/oneeyedmen/anagrams/AnagramTests.kt
@@ -16,21 +16,6 @@ val words: List<String> = File("./words.txt").readLines()
 class AnagramTests {
 
     @Test
-    fun `could be made from the letters in`() {
-        assertTrue("A".couldBeMadeFromTheLettersIn("A CAT"))
-        assertTrue("CAT".couldBeMadeFromTheLettersIn("A CAT"))
-        assertTrue("AA".couldBeMadeFromTheLettersIn("A CAT"))
-        assertTrue("ACT".couldBeMadeFromTheLettersIn("A CAT"))
-
-        assertFalse("H".couldBeMadeFromTheLettersIn("A CAT"))
-        assertFalse("AAH".couldBeMadeFromTheLettersIn("A CAT"))
-        assertFalse("TAT".couldBeMadeFromTheLettersIn("A CAT"))
-
-        assertTrue("".couldBeMadeFromTheLettersIn("A CAT"))
-        assertTrue("".couldBeMadeFromTheLettersIn(""))
-    }
-
-    @Test
     fun `anagrams for A CAT`() {
         assertEquals(
             listOf("A ACT", "A CAT", "ACTA"),


### PR DESCRIPTION
Following optimizations were done:
- `startingIndex` parameter was added to `process` function to avoid calling `remainingCandidateWords.subList`; instead we can specify this starting index to ignore first words
- checking if the word can be made of letters and calculation of remaining letters combined into one piece of code and now can be done in one go through the word
- defined `IntArray` to keep track of letter counts which makes calculation of remaining letters faster