### PR TITLE
Simple optimizations by avoiding unnecessary operations

### DIFF
--- a/src/main/kotlin/com/oneeyedmen/anagrams/anagrams.kt
+++ b/src/main/kotlin/com/oneeyedmen/anagrams/anagrams.kt
@@ -131,12 +131,14 @@ internal fun List<WordInfo>.combinations(): Set<String> {
 
 private fun List<WordInfo>.permuteInto(
     collector: MutableSet<String>,
-    prefix: String = ""
+    prefix: MutableList<String> = mutableListOf()
 ) {
     when (this.size) {
-        0 -> collector.add(prefix.substring(1).split(" ").sorted().joinToString(" "))
+        0 -> collector.add(prefix.sorted().joinToString(" "))
         else -> this.first().words.forEach { word ->
-            this.subList(1, this.size).permuteInto(collector, prefix = "$prefix $word")
+            prefix.add(word)
+            this.subList(1, this.size).permuteInto(collector, prefix = prefix)
+            prefix.removeLast()
         }
     }
 }

--- a/src/main/kotlin/com/oneeyedmen/anagrams/anagrams.kt
+++ b/src/main/kotlin/com/oneeyedmen/anagrams/anagrams.kt
@@ -124,18 +124,17 @@ private fun String.minusLettersIn(word: String): String {
 }
 
 
-internal fun List<WordInfo>.combinations(): Set<String> =
-    mutableSetOf<String>().apply { permuteInto(this) }
+internal fun List<WordInfo>.combinations(): Set<String> {
+    if (this.isEmpty()) return emptySet()
+    return mutableSetOf<String>().apply { permuteInto(this) }
+}
 
 private fun List<WordInfo>.permuteInto(
     collector: MutableSet<String>,
     prefix: String = ""
 ) {
     when (this.size) {
-        0 -> {}
-        1 -> this.first().words.forEach { word ->
-            collector.add("$prefix $word".substring(1).split(" ").sorted().joinToString(" "))
-        }
+        0 -> collector.add(prefix.substring(1).split(" ").sorted().joinToString(" "))
         else -> this.first().words.forEach { word ->
             this.subList(1, this.size).permuteInto(collector, prefix = "$prefix $word")
         }

--- a/src/main/kotlin/com/oneeyedmen/anagrams/anagrams.kt
+++ b/src/main/kotlin/com/oneeyedmen/anagrams/anagrams.kt
@@ -124,19 +124,17 @@ private fun String.minusLettersIn(word: String): String {
 }
 
 
-private fun List<WordInfo>.combinations(): Set<String> =
-    mutableListOf<String>().apply { permuteInto(this) }
-        .map { it.split(" ").sorted().joinToString(" ") }
-        .toSet()
+internal fun List<WordInfo>.combinations(): Set<String> =
+    mutableSetOf<String>().apply { permuteInto(this) }
 
-internal fun List<WordInfo>.permuteInto(
-    collector: MutableList<String>,
+private fun List<WordInfo>.permuteInto(
+    collector: MutableSet<String>,
     prefix: String = ""
 ) {
     when (this.size) {
         0 -> {}
         1 -> this.first().words.forEach { word ->
-            collector.add("$prefix $word".substring(1))
+            collector.add("$prefix $word".substring(1).split(" ").sorted().joinToString(" "))
         }
         else -> this.first().words.forEach { word ->
             this.subList(1, this.size).permuteInto(collector, prefix = "$prefix $word")

--- a/src/main/kotlin/com/oneeyedmen/anagrams/anagrams.kt
+++ b/src/main/kotlin/com/oneeyedmen/anagrams/anagrams.kt
@@ -30,7 +30,7 @@ private fun process(
     input: WordInfo,
     words: List<WordInfo>,
     collector: (List<WordInfo>) -> Unit,
-    prefix: List<WordInfo> = emptyList(),
+    prefix: MutableList<WordInfo> = mutableListOf(),
     depth: Int,
     instrumentation: (MinusLettersInInvocation) -> Unit = {}
 ) {
@@ -41,19 +41,21 @@ private fun process(
     candidateWords.forEach { wordInfo ->
         instrumentation(MinusLettersInInvocation(input, wordInfo))
         val remainingLetters = input.minusLettersIn(wordInfo)
+        prefix.add(wordInfo)
         when {
             remainingLetters.isEmpty() ->
-                collector(prefix + wordInfo)
+                collector(prefix)
 
             depth > 1 -> process(
                 input = WordInfo(remainingLetters),
                 words = remainingCandidateWords,
                 collector = collector,
-                prefix = prefix + wordInfo,
+                prefix = prefix,
                 depth = depth - 1,
                 instrumentation = instrumentation
             )
         }
+        prefix.removeLast()
         remainingCandidateWords = remainingCandidateWords.subList(
             1, remainingCandidateWords.size
         )

--- a/src/test/kotlin/com/oneeyedmen/anagrams/AnagramImplementationTests.kt
+++ b/src/test/kotlin/com/oneeyedmen/anagrams/AnagramImplementationTests.kt
@@ -39,42 +39,33 @@ class AnagramImplementationTests {
 
     @Test fun `empty WordInfo permutations`() {
         assertEquals(
-            emptyList(),
-            emptyList<WordInfo>().permutations()
+            emptySet(),
+            emptyList<WordInfo>().combinations()
         )
     }
 
     @Test fun `single WordInfo permutations`() {
         assertEquals(
-            listOf("ACT", "CAT"),
-            listOf(WordInfo(listOf("ACT", "CAT"))).permutations()
+            setOf("ACT", "CAT"),
+            listOf(WordInfo(listOf("ACT", "CAT"))).combinations()
         )
     }
 
     @Test fun `WordInfo permutations`() {
         assertEquals(
-            listOf("ACT TAB", "ACT BAT", "CAT TAB", "CAT BAT"),
+            setOf("ACT TAB", "ACT BAT", "CAT TAB", "BAT CAT"),
             listOf(
                 WordInfo(listOf("ACT", "CAT")),
                 WordInfo(listOf("TAB", "BAT"))
-            ).permutations()
+            ).combinations()
         )
         assertEquals(
-            listOf("ACT A TAB", "ACT A BAT", "CAT A TAB", "CAT A BAT"),
+            setOf("A ACT TAB", "A ACT BAT", "A CAT TAB", "A BAT CAT"),
             listOf(
                 WordInfo(listOf("ACT", "CAT")),
                 WordInfo(listOf("A")),
                 WordInfo(listOf("TAB", "BAT"))
-            ).permutations()
+            ).combinations()
         )
     }
 }
-
-private fun List<WordInfo>.permutations(): List<String> {
-    val collector = mutableListOf<String>()
-    permuteInto(collector)
-    return collector
-}
-
-
-


### PR DESCRIPTION
Few small changes that reduced time for `REFACTORING TO KOTL` from `14396` to `10426`.

First optimization is for `process()` function.
`prefix + wordInfo` creates new list and copies all elements from `prefix` list and `wordInfo` element into new list.
We can avoid it by keeping and modifying just one list.

And then the same optimization for `permuteInto()` function.
We were concatenating a lot of strings just to split them back to a list right before adding to a resulting list.