### PR TITLE
Collect words into String to reduce number of concats

### DIFF
--- a/src/main/kotlin/com/oneeyedmen/anagrams/anagrams.kt
+++ b/src/main/kotlin/com/oneeyedmen/anagrams/anagrams.kt
@@ -190,20 +190,22 @@ internal fun String.toLetterBitSet(): LetterBitSet {
 
 internal fun List<WordInfo>.permuteInto(
     collector: MutableList<String>,
-    prefix: MutableList<String> = mutableListOf(),
+    prefix: String = "",
     wordIndexes: MutableMap<WordInfo, Int> = mutableMapOf<WordInfo, Int>().withDefault { 0 }
 ) {
     when (this.size) {
-        0 -> collector.add(prefix.joinToString(" "))
+        0 -> collector.add(prefix)
         else -> {
             val wordInfo = this.first()
             val wordIndex = wordIndexes.getValue(wordInfo)
             wordInfo.words.forEachIndexed { index, word ->
                 if (index < wordIndex) return@forEachIndexed
-                prefix.add(word)
                 wordIndexes[wordInfo] = index
-                this.subListFrom(1).permuteInto(collector, prefix, wordIndexes)
-                prefix.removeLast()
+                this.subListFrom(1).permuteInto(
+                    collector,
+                    if (prefix.isEmpty()) word else "$prefix $word",
+                    wordIndexes
+                )
             }
             wordIndexes[wordInfo] = wordIndex
         }


### PR DESCRIPTION
Function `permuteInto` is generating unique results and we don't need to sort words, so we can go back to your previous way to construct `prefix`, i.e. have it as a `String` instead of `List<String>`. This way we are doing way less string concatenations.
Time has reduces from 3500 to 3100.